### PR TITLE
Add quant analysis pipeline with technical scoring

### DIFF
--- a/src/adapters/__init__.py
+++ b/src/adapters/__init__.py
@@ -1,6 +1,35 @@
 """Data source adapters for crypto market data."""
 
+from typing import Dict, Type
+
 from .base import BaseAdapter
 from .coingecko import CoinGeckoAdapter
 
-__all__ = ["BaseAdapter", "CoinGeckoAdapter"]
+ADAPTER_REGISTRY: Dict[str, Type[BaseAdapter]] = {
+    "coingecko": CoinGeckoAdapter,
+}
+
+
+def get_adapter(name: str, **kwargs) -> BaseAdapter:
+    """Return an adapter instance by name.
+
+    Args:
+        name: Name of the adapter registered in :data:`ADAPTER_REGISTRY`.
+        **kwargs: Keyword arguments forwarded to the adapter constructor.
+
+    Raises:
+        ValueError: If the adapter name is not registered.
+
+    Returns:
+        Instantiated adapter ready for use.
+    """
+
+    try:
+        adapter_cls = ADAPTER_REGISTRY[name.lower()]
+    except KeyError as exc:
+        raise ValueError(f"Unknown adapter: {name}") from exc
+
+    return adapter_cls(**kwargs)
+
+
+__all__ = ["BaseAdapter", "CoinGeckoAdapter", "get_adapter", "ADAPTER_REGISTRY"]

--- a/src/adapters/coingecko.py
+++ b/src/adapters/coingecko.py
@@ -264,6 +264,7 @@ class CoinGeckoAdapter(BaseAdapter):
             "high": [],
             "low": [],
             "close": [],
+            "volume": [],
         }
 
         for candle in data:
@@ -273,6 +274,11 @@ class CoinGeckoAdapter(BaseAdapter):
             ohlcv["high"].append(h)
             ohlcv["low"].append(l)
             ohlcv["close"].append(c)
+            # The OHLC endpoint does not return volume, but downstream
+            # analytics expect the key to exist. We fill with None values
+            # so analytics modules can gracefully skip volume-based signals
+            # when the data source does not provide it.
+            ohlcv["volume"].append(None)
 
         return ohlcv
 

--- a/src/analysis/__init__.py
+++ b/src/analysis/__init__.py
@@ -1,0 +1,5 @@
+"""Analysis modules powering the quant pipeline."""
+
+from .technical import TechnicalAnalyzer
+
+__all__ = ["TechnicalAnalyzer"]

--- a/src/analysis/technical.py
+++ b/src/analysis/technical.py
@@ -1,0 +1,422 @@
+"""Technical indicator evaluation for digital assets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+import numpy as np
+import pandas as pd
+import structlog
+
+from src.models import IndicatorScore, TechnicalAnalysisResult
+
+logger = structlog.get_logger()
+
+
+@dataclass(frozen=True)
+class _IndicatorConfig:
+    enabled: bool
+    weight: float
+
+
+class TechnicalAnalyzer:
+    """Evaluate market structure using classical technical indicators."""
+
+    _RESAMPLE_MAP = {
+        "5m": "5T",
+        "15m": "15T",
+        "1h": "1H",
+        "4h": "4H",
+        "1d": "1D",
+    }
+
+    def __init__(self, config: Dict[str, Dict]) -> None:
+        self.config = config
+        self.timeframes = config.get("timeframes", ["1d"])
+        self.indicator_config = self._load_indicator_config(config.get("indicators", {}))
+
+    def evaluate_timeframes(self, data: pd.DataFrame) -> Dict[str, TechnicalAnalysisResult]:
+        """Evaluate configured indicators across timeframes."""
+
+        results: Dict[str, TechnicalAnalysisResult] = {}
+        for timeframe in self.timeframes:
+            prepared = self._prepare_timeframe(data, timeframe)
+            if prepared is None or prepared.empty:
+                logger.warning(
+                    "technical.analyzer.insufficient_data", timeframe=timeframe, bars=len(data)
+                )
+                continue
+
+            results[timeframe] = self._analyze_single(prepared, timeframe)
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _load_indicator_config(self, config: Dict[str, Dict]) -> Dict[str, _IndicatorConfig]:
+        indicator_config: Dict[str, _IndicatorConfig] = {}
+        for name, params in config.items():
+            indicator_config[name] = _IndicatorConfig(
+                enabled=bool(params.get("enabled", True)),
+                weight=float(params.get("weight", 0.0)),
+            )
+        return indicator_config
+
+    def _prepare_timeframe(self, data: pd.DataFrame, timeframe: str) -> pd.DataFrame | None:
+        if timeframe not in self._RESAMPLE_MAP:
+            logger.warning("technical.analyzer.unsupported_timeframe", timeframe=timeframe)
+            return None
+
+        if not isinstance(data.index, pd.DatetimeIndex):
+            raise ValueError("DataFrame index must be a DatetimeIndex for technical analysis")
+
+        rule = self._RESAMPLE_MAP[timeframe]
+        agg_map = {
+            "open": "first",
+            "high": "max",
+            "low": "min",
+            "close": "last",
+        }
+        if "volume" in data.columns:
+            agg_map["volume"] = "sum"
+
+        resampled = data.resample(rule).agg(agg_map).dropna(subset=["open", "high", "low", "close"])
+
+        if "volume" not in resampled.columns:
+            resampled["volume"] = np.nan
+
+        return resampled
+
+    def _analyze_single(self, data: pd.DataFrame, timeframe: str) -> TechnicalAnalysisResult:
+        indicator_scores: List[IndicatorScore] = []
+        signals: List[str] = []
+
+        close = data["close"]
+        volume = data["volume"] if "volume" in data.columns else pd.Series(dtype="float64")
+
+        weights_sum = sum(cfg.weight for cfg in self.indicator_config.values() if cfg.enabled)
+        composite = 0.0
+
+        if self._is_enabled("rsi"):
+            score, indicator, rsi_signal = self._evaluate_rsi(close, timeframe)
+            indicator_scores.append(indicator)
+            composite += score
+            signals.extend(rsi_signal)
+
+        if self._is_enabled("macd"):
+            score, indicator, macd_signal = self._evaluate_macd(close, timeframe)
+            indicator_scores.append(indicator)
+            composite += score
+            signals.extend(macd_signal)
+
+        if self._is_enabled("bollinger_bands"):
+            score, indicator, bb_signal = self._evaluate_bollinger(close, timeframe)
+            indicator_scores.append(indicator)
+            composite += score
+            signals.extend(bb_signal)
+
+        if self._is_enabled("volume_analysis") and not volume.empty and volume.notna().any():
+            score, indicator, vol_signal = self._evaluate_volume(volume, timeframe)
+            indicator_scores.append(indicator)
+            composite += score
+            signals.extend(vol_signal)
+
+        if self._is_enabled("support_resistance"):
+            score, indicator, sr_signal = self._evaluate_support_resistance(data, timeframe)
+            indicator_scores.append(indicator)
+            composite += score
+            signals.extend(sr_signal)
+
+        if weights_sum > 0:
+            composite_score = composite / weights_sum
+        else:
+            composite_score = 0.0
+
+        bias = self._bias_from_score(composite_score)
+
+        return TechnicalAnalysisResult(
+            timeframe=timeframe,
+            composite_score=composite_score,
+            indicator_scores=indicator_scores,
+            signals=sorted(set(signals)),
+            bias=bias,
+            metadata={"bars": len(data)},
+        )
+
+    def _is_enabled(self, name: str) -> bool:
+        cfg = self.indicator_config.get(name, _IndicatorConfig(enabled=False, weight=0))
+        return cfg.enabled and cfg.weight > 0
+
+    # Indicator evaluation -------------------------------------------------
+    def _evaluate_rsi(
+        self, close: pd.Series, timeframe: str
+    ) -> Tuple[float, IndicatorScore, List[str]]:
+        params = self.config["indicators"].get("rsi", {})
+        period = int(params.get("period", 14))
+        oversold = float(params.get("oversold", 30))
+        overbought = float(params.get("overbought", 70))
+        weight = float(params.get("weight", 0))
+
+        if len(close) < period + 1:
+            rsi_value = np.nan
+        else:
+            delta = close.diff()
+            gains = delta.clip(lower=0)
+            losses = -delta.clip(upper=0)
+            avg_gain = gains.ewm(alpha=1 / period, adjust=False).mean()
+            avg_loss = losses.ewm(alpha=1 / period, adjust=False).mean()
+            rs = avg_gain / avg_loss.replace({0: np.nan})
+            rsi = 100 - (100 / (1 + rs))
+            rsi_value = float(rsi.iloc[-1])
+
+        score = self._score_rsi(rsi_value, oversold, overbought) * weight
+
+        signals: List[str] = []
+        if not np.isnan(rsi_value):
+            if rsi_value < oversold:
+                signals.append(f"{timeframe} RSI oversold")
+            elif rsi_value > overbought:
+                signals.append(f"{timeframe} RSI overbought")
+
+        indicator = IndicatorScore(
+            name="RSI",
+            value=float(rsi_value) if not np.isnan(rsi_value) else float("nan"),
+            score=score / weight if weight else 0.0,
+            weight=weight,
+            timeframe=timeframe,
+            metadata={"period": period, "oversold": oversold, "overbought": overbought},
+        )
+
+        return score, indicator, signals
+
+    def _score_rsi(self, value: float, oversold: float, overbought: float) -> float:
+        if np.isnan(value):
+            return 0.0
+
+        if value < oversold:
+            return min(100.0, 100 - ((oversold - value) / oversold) * 20)
+        if value > overbought:
+            return max(0.0, 100 - ((value - overbought) / (100 - overbought)) * 100)
+
+        distance = abs(value - 50)
+        return max(0.0, 100 - (distance / 50) * 100)
+
+    def _evaluate_macd(
+        self, close: pd.Series, timeframe: str
+    ) -> Tuple[float, IndicatorScore, List[str]]:
+        params = self.config["indicators"].get("macd", {})
+        fast = int(params.get("fast", 12))
+        slow = int(params.get("slow", 26))
+        signal = int(params.get("signal", 9))
+        weight = float(params.get("weight", 0))
+
+        if len(close) < slow + signal:
+            macd_value = signal_value = hist_value = np.nan
+        else:
+            ema_fast = close.ewm(span=fast, adjust=False).mean()
+            ema_slow = close.ewm(span=slow, adjust=False).mean()
+            macd_line = ema_fast - ema_slow
+            signal_line = macd_line.ewm(span=signal, adjust=False).mean()
+            hist = macd_line - signal_line
+            macd_value = float(macd_line.iloc[-1])
+            signal_value = float(signal_line.iloc[-1])
+            hist_value = float(hist.iloc[-1])
+
+        score = self._score_macd(hist_value) * weight
+
+        signals: List[str] = []
+        if not np.isnan(hist_value):
+            if hist_value > 0:
+                signals.append(f"{timeframe} MACD bullish")
+            elif hist_value < 0:
+                signals.append(f"{timeframe} MACD bearish")
+
+        indicator = IndicatorScore(
+            name="MACD",
+            value=macd_value if not np.isnan(macd_value) else float("nan"),
+            score=score / weight if weight else 0.0,
+            weight=weight,
+            timeframe=timeframe,
+            metadata={
+                "fast": fast,
+                "slow": slow,
+                "signal": signal,
+                "signal_value": signal_value,
+                "histogram": hist_value,
+            },
+        )
+
+        return score, indicator, signals
+
+    def _score_macd(self, hist_value: float) -> float:
+        if np.isnan(hist_value):
+            return 0.0
+
+        # Normalize the histogram by using an arctangent to bound values.
+        normalized = (np.arctan(hist_value) / (np.pi / 2) + 1) / 2
+        return normalized * 100
+
+    def _evaluate_bollinger(
+        self, close: pd.Series, timeframe: str
+    ) -> Tuple[float, IndicatorScore, List[str]]:
+        params = self.config["indicators"].get("bollinger_bands", {})
+        period = int(params.get("period", 20))
+        std_dev = float(params.get("std_dev", 2))
+        weight = float(params.get("weight", 0))
+
+        if len(close) < period:
+            bb_position = np.nan
+            upper = lower = middle = np.nan
+        else:
+            middle = close.rolling(window=period).mean()
+            std = close.rolling(window=period).std(ddof=0)
+            upper = middle + std_dev * std
+            lower = middle - std_dev * std
+            bb_position = (close - lower) / (upper - lower)
+            bb_position = float(bb_position.iloc[-1])
+            upper = float(upper.iloc[-1])
+            lower = float(lower.iloc[-1])
+            middle = float(middle.iloc[-1])
+
+        score = self._score_bollinger(bb_position) * weight
+
+        signals: List[str] = []
+        if not np.isnan(bb_position):
+            if bb_position < 0.1:
+                signals.append(f"{timeframe} price near lower band")
+            elif bb_position > 0.9:
+                signals.append(f"{timeframe} price near upper band")
+
+        indicator = IndicatorScore(
+            name="Bollinger Bands",
+            value=bb_position if not np.isnan(bb_position) else float("nan"),
+            score=score / weight if weight else 0.0,
+            weight=weight,
+            timeframe=timeframe,
+            metadata={
+                "period": period,
+                "std_dev": std_dev,
+                "upper": upper,
+                "lower": lower,
+                "middle": middle,
+            },
+        )
+
+        return score, indicator, signals
+
+    def _score_bollinger(self, position: float) -> float:
+        if np.isnan(position):
+            return 0.0
+
+        # Favor prices near the lower band (potential entries) and penalize
+        # extreme upper band moves to avoid chasing pumps.
+        if position <= 0.5:
+            return (1 - position) * 100
+        return max(0.0, (1 - position) * 60)
+
+    def _evaluate_volume(
+        self, volume: pd.Series, timeframe: str
+    ) -> Tuple[float, IndicatorScore, List[str]]:
+        params = self.config["indicators"].get("volume_analysis", {})
+        period = int(params.get("sma_period", 20))
+        spike_threshold = float(params.get("spike_threshold", 2.0))
+        weight = float(params.get("weight", 0))
+
+        if len(volume.dropna()) < period:
+            ratio = np.nan
+        else:
+            sma = volume.rolling(window=period).mean()
+            ratio = float((volume.iloc[-1] / sma.iloc[-1]) if sma.iloc[-1] else np.nan)
+
+        score = self._score_volume(ratio, spike_threshold) * weight
+
+        signals: List[str] = []
+        if not np.isnan(ratio):
+            if ratio >= spike_threshold:
+                signals.append(f"{timeframe} volume breakout")
+            elif ratio < 0.5:
+                signals.append(f"{timeframe} volume drought")
+
+        indicator = IndicatorScore(
+            name="Volume Surge",
+            value=ratio if not np.isnan(ratio) else float("nan"),
+            score=score / weight if weight else 0.0,
+            weight=weight,
+            timeframe=timeframe,
+            metadata={"period": period, "spike_threshold": spike_threshold},
+        )
+
+        return score, indicator, signals
+
+    def _score_volume(self, ratio: float, threshold: float) -> float:
+        if np.isnan(ratio):
+            return 0.0
+
+        if ratio >= threshold:
+            return min(100.0, (ratio / threshold) * 100)
+
+        return max(0.0, (ratio / threshold) * 60)
+
+    def _evaluate_support_resistance(
+        self, data: pd.DataFrame, timeframe: str
+    ) -> Tuple[float, IndicatorScore, List[str]]:
+        params = self.config["indicators"].get("support_resistance", {})
+        lookback = int(params.get("lookback_periods", 100))
+        weight = float(params.get("weight", 0))
+
+        window = data.tail(lookback)
+        if window.empty:
+            return 0.0, IndicatorScore("Support/Resistance", float("nan"), 0.0, weight, timeframe), []
+
+        recent_low = float(window["low"].min())
+        recent_high = float(window["high"].max())
+        close = float(window["close"].iloc[-1])
+
+        support_distance = (close - recent_low) / recent_low if recent_low else np.nan
+        resistance_distance = (recent_high - close) / recent_high if recent_high else np.nan
+
+        score = self._score_support_resistance(support_distance, resistance_distance) * weight
+
+        signals: List[str] = []
+        if not np.isnan(support_distance) and support_distance < 0.05:
+            signals.append(f"{timeframe} near support")
+        if not np.isnan(resistance_distance) and resistance_distance < 0.05:
+            signals.append(f"{timeframe} near resistance")
+
+        indicator = IndicatorScore(
+            name="Support/Resistance",
+            value=close,
+            score=score / weight if weight else 0.0,
+            weight=weight,
+            timeframe=timeframe,
+            metadata={
+                "recent_low": recent_low,
+                "recent_high": recent_high,
+                "support_distance": support_distance,
+                "resistance_distance": resistance_distance,
+            },
+        )
+
+        return score, indicator, signals
+
+    def _score_support_resistance(self, support_dist: float, resistance_dist: float) -> float:
+        if np.isnan(support_dist) or np.isnan(resistance_dist):
+            return 0.0
+
+        # Favor entries closer to support with adequate room to resistance.
+        buffer = resistance_dist + support_dist
+        if buffer == 0:
+            return 50.0
+
+        skew = resistance_dist - support_dist
+        normalized = (skew / buffer + 1) / 2  # Map to 0-1
+        return normalized * 100
+
+    def _bias_from_score(self, score: float) -> str:
+        if score >= 65:
+            return "bullish"
+        if score <= 35:
+            return "bearish"
+        return "neutral"

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -1,0 +1,40 @@
+"""Utilities for loading and working with strategy configuration files."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+
+class ConfigLoader:
+    """Load YAML based configuration profiles.
+
+    Parameters
+    ----------
+    path:
+        Path to a YAML configuration file. The loader caches parsed
+        configurations to avoid re-reading the same file multiple times.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        if not self.path.exists():
+            raise FileNotFoundError(f"Configuration file not found: {self.path}")
+
+    @lru_cache(maxsize=8)
+    def load(self) -> Dict[str, Any]:
+        """Parse the YAML configuration file and return a dictionary."""
+
+        with self.path.open("r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+
+        if not isinstance(data, dict):
+            raise ValueError(
+                "Configuration root must be a mapping (dict); "
+                f"received type {type(data)!r}"
+            )
+
+        return data

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,5 @@
+"""Dataclasses and value objects shared across the analytics pipeline."""
+
+from .analysis import AssetSignal, IndicatorScore, TechnicalAnalysisResult
+
+__all__ = ["AssetSignal", "IndicatorScore", "TechnicalAnalysisResult"]

--- a/src/models/analysis.py
+++ b/src/models/analysis.py
@@ -1,0 +1,85 @@
+"""Dataclasses describing analysis and signal outputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+@dataclass(slots=True)
+class IndicatorScore:
+    """Result of a single indicator evaluation."""
+
+    name: str
+    value: float
+    score: float
+    weight: float
+    timeframe: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class TechnicalAnalysisResult:
+    """Aggregate of technical indicators for a timeframe."""
+
+    timeframe: str
+    composite_score: float
+    indicator_scores: List[IndicatorScore]
+    signals: List[str] = field(default_factory=list)
+    bias: str = "neutral"
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the result to a JSON-compatible dictionary."""
+
+        return {
+            "timeframe": self.timeframe,
+            "composite_score": self.composite_score,
+            "indicator_scores": [
+                {
+                    "name": indicator.name,
+                    "value": indicator.value,
+                    "score": indicator.score,
+                    "weight": indicator.weight,
+                    "timeframe": indicator.timeframe,
+                    "metadata": indicator.metadata,
+                }
+                for indicator in self.indicator_scores
+            ],
+            "signals": self.signals,
+            "bias": self.bias,
+            "metadata": self.metadata,
+        }
+
+
+@dataclass(slots=True)
+class AssetSignal:
+    """Composite signal for a digital asset."""
+
+    asset_id: str
+    symbol: str
+    name: str
+    composite_score: float
+    confidence: str
+    signals: List[str]
+    analyzer_breakdown: Dict[str, float]
+    technical: Dict[str, TechnicalAnalysisResult] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the signal into a JSON-compatible dictionary."""
+
+        return {
+            "asset_id": self.asset_id,
+            "symbol": self.symbol,
+            "name": self.name,
+            "composite_score": self.composite_score,
+            "confidence": self.confidence,
+            "signals": self.signals,
+            "analyzer_breakdown": self.analyzer_breakdown,
+            "technical": {
+                timeframe: result.to_dict()
+                for timeframe, result in self.technical.items()
+            },
+            "metadata": self.metadata,
+        }

--- a/src/pipeline/__init__.py
+++ b/src/pipeline/__init__.py
@@ -1,0 +1,5 @@
+"""Orchestration logic for the quant screening pipeline."""
+
+from .scanner import QuantScanner
+
+__all__ = ["QuantScanner"]

--- a/src/pipeline/scanner.py
+++ b/src/pipeline/scanner.py
@@ -1,0 +1,219 @@
+"""Quantitative crypto asset screening pipeline."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Dict, Iterable, List, Optional
+
+import numpy as np
+import pandas as pd
+import structlog
+
+from src.analysis import TechnicalAnalyzer
+from src.adapters import BaseAdapter, get_adapter
+from src.config_loader import ConfigLoader
+from src.models import AssetSignal, TechnicalAnalysisResult
+
+logger = structlog.get_logger()
+
+
+class QuantScanner:
+    """Coordinate data ingestion, analysis, and signal generation."""
+
+    def __init__(self, config_path: str, adapter: Optional[BaseAdapter] = None) -> None:
+        self.config_loader = ConfigLoader(config_path)
+        self.config = self.config_loader.load()
+        self.adapter = adapter
+
+        price_source = self.config.get("data_sources", {}).get("price_data", {})
+        self.adapter_name = price_source.get("primary", "coingecko")
+        adapter_kwargs = {}
+        if api_key := price_source.get("api_key"):
+            adapter_kwargs["api_key"] = api_key
+        self.adapter_kwargs = adapter_kwargs
+
+        technical_config = self.config.get("technical_analysis", {})
+        self.technical_analyzer = TechnicalAnalyzer(technical_config)
+        self.analyzer_weights = self.config.get("analyzer_weights", {"technical": 1.0})
+        self.score_ranges = self.config.get("scoring", {}).get("score_ranges", {})
+
+    async def analyze_assets(self, coin_ids: Iterable[str], days: int = 90) -> List[AssetSignal]:
+        """Run the full quant pipeline for the provided assets."""
+
+        coin_ids = [coin_id for coin_id in coin_ids if coin_id]
+        if not coin_ids:
+            return []
+
+        adapter = self.adapter or get_adapter(self.adapter_name, **self.adapter_kwargs)
+
+        if self.adapter is None:
+            async with adapter as managed_adapter:
+                return await self._analyze_with_adapter(managed_adapter, coin_ids, days)
+
+        return await self._analyze_with_adapter(adapter, coin_ids, days)
+
+    async def _analyze_with_adapter(
+        self, adapter: BaseAdapter, coin_ids: Iterable[str], days: int
+    ) -> List[AssetSignal]:
+        tasks = [self._analyze_asset(adapter, coin_id, days) for coin_id in coin_ids]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        signals: List[AssetSignal] = []
+        for coin_id, result in zip(coin_ids, results):
+            if isinstance(result, Exception):
+                logger.error("quant_scanner.analysis_failed", asset=coin_id, error=str(result))
+                continue
+            if result is None:
+                continue
+            signals.append(result)
+
+        signals.sort(key=lambda item: item.composite_score, reverse=True)
+        return signals
+
+    async def _analyze_asset(
+        self, adapter: BaseAdapter, coin_id: str, days: int
+    ) -> Optional[AssetSignal]:
+        try:
+            asset = await adapter.get_asset_data(coin_id)
+            ohlcv = await adapter.get_ohlcv(coin_id, days=days)
+        except Exception as exc:  # noqa: BLE001 - We want to bubble the error with context
+            logger.error("quant_scanner.data_fetch_failed", asset=coin_id, error=str(exc))
+            return None
+
+        frame = self._ohlcv_to_dataframe(ohlcv)
+        if frame.empty:
+            logger.warning("quant_scanner.empty_market_data", asset=coin_id)
+            return None
+
+        technical_results = self.technical_analyzer.evaluate_timeframes(frame)
+        if not technical_results:
+            logger.warning("quant_scanner.no_technical_signal", asset=coin_id)
+            return None
+
+        module_scores: Dict[str, float] = {}
+        technical_score = self._aggregate_timeframe_results(technical_results)
+        if technical_score is not None:
+            module_scores["technical"] = technical_score
+
+        composite_score = self._combine_module_scores(module_scores)
+        confidence = self._score_to_label(composite_score)
+        aggregated_signals = self._collect_signals(technical_results)
+
+        analyzer_breakdown = {
+            name: module_scores.get(name, 0.0) for name in self.analyzer_weights.keys()
+        }
+
+        metadata = {
+            "asset": {
+                "market_cap": asset.get("market_cap"),
+                "market_cap_rank": asset.get("market_cap_rank"),
+                "total_volume": asset.get("total_volume"),
+                "price_usd": asset.get("price_usd"),
+            },
+            "risk_profile": self.config.get("profile", {}).get("name"),
+        }
+
+        return AssetSignal(
+            asset_id=asset.get("id", coin_id),
+            symbol=asset.get("symbol", coin_id.upper()),
+            name=asset.get("name", coin_id.title()),
+            composite_score=composite_score,
+            confidence=confidence,
+            signals=aggregated_signals,
+            analyzer_breakdown=analyzer_breakdown,
+            technical=technical_results,
+            metadata=metadata,
+        )
+
+    def _ohlcv_to_dataframe(self, data: Dict[str, List]) -> pd.DataFrame:
+        if not data:
+            return pd.DataFrame()
+
+        timestamps = data.get("timestamps")
+        if not timestamps:
+            return pd.DataFrame()
+
+        frame = pd.DataFrame(
+            {
+                "timestamp": pd.to_datetime(data.get("timestamps"), unit="ms", utc=True),
+                "open": pd.to_numeric(data.get("open", []), errors="coerce"),
+                "high": pd.to_numeric(data.get("high", []), errors="coerce"),
+                "low": pd.to_numeric(data.get("low", []), errors="coerce"),
+                "close": pd.to_numeric(data.get("close", []), errors="coerce"),
+            }
+        )
+
+        if "volume" in data:
+            frame["volume"] = pd.to_numeric(data.get("volume", []), errors="coerce")
+
+        frame = frame.set_index("timestamp").sort_index()
+        return frame.dropna(subset=["open", "high", "low", "close"])
+
+    def _aggregate_timeframe_results(
+        self, results: Dict[str, TechnicalAnalysisResult]
+    ) -> Optional[float]:
+        if not results:
+            return None
+
+        frames = [tf for tf in self.technical_analyzer.timeframes if tf in results]
+        if not frames:
+            frames = list(results.keys())
+
+        weights = np.linspace(1, len(frames), len(frames))
+        weights = weights / weights.sum()
+
+        aggregated = 0.0
+        for weight, timeframe in zip(weights, frames, strict=False):
+            aggregated += results[timeframe].composite_score * weight
+
+        return aggregated
+
+    def _combine_module_scores(self, module_scores: Dict[str, float]) -> float:
+        weighted = 0.0
+        total_weight = 0.0
+
+        for name, score in module_scores.items():
+            weight = float(self.analyzer_weights.get(name, 0.0))
+            if weight <= 0:
+                continue
+            weighted += score * weight
+            total_weight += weight
+
+        if total_weight == 0:
+            return 0.0
+
+        return weighted / total_weight
+
+    def _collect_signals(self, results: Dict[str, TechnicalAnalysisResult]) -> List[str]:
+        aggregated: List[str] = []
+        for timeframe, result in results.items():
+            aggregated.extend(result.signals or [f"{timeframe} neutral"])
+        return sorted(set(aggregated))
+
+    def _score_to_label(self, score: float) -> str:
+        if not self.score_ranges:
+            return "unclassified"
+
+        for label, bounds in self.score_ranges.items():
+            if not isinstance(bounds, (list, tuple)) or len(bounds) != 2:
+                continue
+            lower, upper = bounds
+            if lower <= score <= upper:
+                return label
+
+        # If the score is outside declared bands, pick the closest range.
+        closest_label = "unclassified"
+        smallest_distance = float("inf")
+        for label, bounds in self.score_ranges.items():
+            if not isinstance(bounds, (list, tuple)) or len(bounds) != 2:
+                continue
+            lower, upper = bounds
+            if score < lower:
+                distance = lower - score
+            else:
+                distance = score - upper
+            if distance < smallest_distance:
+                smallest_distance = distance
+                closest_label = label
+
+        return closest_label

--- a/tests/test_technical_analyzer.py
+++ b/tests/test_technical_analyzer.py
@@ -1,0 +1,58 @@
+"""Unit tests for the technical analyzer."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import numpy as np
+import pandas as pd
+
+from src.analysis import TechnicalAnalyzer
+
+
+def build_sample_dataframe(periods: int = 120) -> pd.DataFrame:
+    start = datetime(2023, 1, 1)
+    index = pd.date_range(start=start, periods=periods, freq="H", tz="UTC")
+
+    base = np.linspace(100, 140, periods)
+    noise = np.random.default_rng(42).normal(scale=2.5, size=periods)
+    close = base + noise
+    open_ = close + np.random.default_rng(43).normal(scale=1.2, size=periods)
+    high = np.maximum(open_, close) + np.random.default_rng(44).uniform(0, 2, periods)
+    low = np.minimum(open_, close) - np.random.default_rng(45).uniform(0, 2, periods)
+    volume = np.abs(np.random.default_rng(46).normal(loc=1_000_000, scale=150_000, size=periods))
+
+    return pd.DataFrame(
+        {
+            "open": open_,
+            "high": high,
+            "low": low,
+            "close": close,
+            "volume": volume,
+        },
+        index=index,
+    )
+
+
+def test_technical_analyzer_generates_scores():
+    config = {
+        "timeframes": ["1h", "4h", "1d"],
+        "indicators": {
+            "rsi": {"enabled": True, "period": 14, "weight": 0.2},
+            "macd": {"enabled": True, "fast": 12, "slow": 26, "signal": 9, "weight": 0.2},
+            "bollinger_bands": {"enabled": True, "period": 20, "std_dev": 2, "weight": 0.2},
+            "volume_analysis": {"enabled": True, "sma_period": 20, "weight": 0.2},
+            "support_resistance": {"enabled": True, "lookback_periods": 60, "weight": 0.2},
+        },
+    }
+
+    analyzer = TechnicalAnalyzer(config)
+    df = build_sample_dataframe()
+
+    results = analyzer.evaluate_timeframes(df)
+
+    assert set(results.keys()) == {"1h", "4h", "1d"}
+    for timeframe, result in results.items():
+        assert result.composite_score >= 0
+        assert result.bias in {"bullish", "bearish", "neutral"}
+        assert result.indicator_scores, f"No indicator scores for timeframe {timeframe}"


### PR DESCRIPTION
## Summary
- add an adapter registry helper and ensure OHLC responses expose a volume key
- introduce configuration loading, analysis dataclasses, and a technical analysis engine with institutional-grade signals
- wire a quant scanner pipeline around the new analyzer and cover it with unit tests

## Testing
- pytest *(fails: numpy dependency unavailable in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5d4fc77288325845e96b60c8d4f43