### PR TITLE
Add multi-factor analyzers and integrate into quant scanner

### DIFF
--- a/src/analysis/__init__.py
+++ b/src/analysis/__init__.py
@@ -1,5 +1,15 @@
 """Analysis modules powering the quant pipeline."""
 
+from .market_structure import MarketStructureAnalyzer
+from .onchain import OnChainAnalyzer
+from .risk import RiskAnalyzer
+from .sentiment import SentimentAnalyzer
 from .technical import TechnicalAnalyzer
 
-__all__ = ["TechnicalAnalyzer"]
+__all__ = [
+    "MarketStructureAnalyzer",
+    "OnChainAnalyzer",
+    "RiskAnalyzer",
+    "SentimentAnalyzer",
+    "TechnicalAnalyzer",
+]

--- a/src/analysis/market_structure.py
+++ b/src/analysis/market_structure.py
@@ -1,0 +1,99 @@
+"""Market structure scoring focused on liquidity and venue diversity."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from src.models import ModuleResult
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _score_ratio(value: float, target: float) -> float:
+    if target <= 0:
+        return 0.0
+
+    ratio = min(value / target, 2.0) / 2.0
+    return max(0.0, min(1.0, ratio)) * 100
+
+
+class MarketStructureAnalyzer:
+    """Evaluate liquidity depth and venue mix."""
+
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        self.config = config or {}
+
+    def analyze(self, asset: Dict[str, Any]) -> ModuleResult:
+        weights_and_scores: List[Tuple[float, float]] = []
+        signals: List[str] = []
+        metrics: Dict[str, Any] = {}
+
+        liquidity_cfg = self.config.get("liquidity_metrics", {}) or {}
+        if liquidity_cfg:
+            weight = float(liquidity_cfg.get("weight", 0.0))
+            if weight > 0:
+                depth = _safe_float(asset.get("total_volume"))
+                target = _safe_float(liquidity_cfg.get("min_depth_usd"), default=50_000)
+                depth_score = _score_ratio(depth, max(1.0, target))
+                weights_and_scores.append((weight, depth_score))
+                metrics["depth_usd"] = depth
+                if depth < target:
+                    signals.append("liquidity depth below target")
+
+                slippage_target = _safe_float(liquidity_cfg.get("max_slippage_5k"), default=0.05)
+                if depth <= 0:
+                    slippage_proxy = 1.0
+                else:
+                    slippage_proxy = min(1.0, 5_000 / (depth + 1))
+                metrics["slippage_proxy"] = slippage_proxy
+                if slippage_proxy > slippage_target:
+                    signals.append("slippage risk elevated")
+
+        venues_cfg = self.config.get("exchange_distribution", {}) or {}
+        cex_weight = float(venues_cfg.get("cex_weight", 0.0))
+        dex_weight = float(venues_cfg.get("dex_weight", 0.0))
+
+        rank = _safe_float(asset.get("market_cap_rank"), default=1_000)
+        if cex_weight > 0:
+            # Higher ranked assets are more likely to be listed on CEX venues.
+            rank_score = max(0.0, min(1.0, (400 - rank) / 400)) * 100
+            weights_and_scores.append((cex_weight, rank_score))
+            metrics["market_cap_rank"] = rank
+            if rank > 300:
+                signals.append("limited tier-1 exchange coverage")
+
+        if dex_weight > 0:
+            # Use trading volume as proxy for DEX availability.
+            dex_volume = _safe_float(asset.get("total_volume"))
+            dex_score = _score_ratio(dex_volume, target=100_000)
+            weights_and_scores.append((dex_weight, dex_score))
+            metrics["dex_volume_proxy"] = dex_volume
+            if dex_volume < 50_000:
+                signals.append("dex liquidity thin")
+
+        if not weights_and_scores:
+            return ModuleResult(
+                name="market_structure",
+                score=0.0,
+                signals=["market structure data unavailable"],
+                metrics=metrics,
+            )
+
+        total_weight = sum(weight for weight, _ in weights_and_scores)
+        if total_weight <= 0:
+            score = 0.0
+        else:
+            score = sum(weight * value for weight, value in weights_and_scores) / total_weight
+
+        return ModuleResult(
+            name="market_structure",
+            score=score,
+            signals=sorted(set(signals)),
+            metrics=metrics,
+        )
+

--- a/src/analysis/onchain.py
+++ b/src/analysis/onchain.py
@@ -1,0 +1,147 @@
+"""Heuristic on-chain analytics leveraging available market metadata."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+import math
+
+from src.models import ModuleResult
+
+
+def _safe_ratio(numerator: Any, denominator: Any) -> float:
+    try:
+        num = float(numerator)
+        den = float(denominator)
+    except (TypeError, ValueError):
+        return 0.0
+
+    if den <= 0:
+        return 0.0
+
+    return max(0.0, num) / den
+
+
+def _scale_ratio(value: float, target: float) -> float:
+    if target <= 0:
+        return 0.0
+
+    # Clamp to twice the target so extreme outliers do not dominate scoring.
+    scaled = min(value / target, 2.0) / 2.0
+    return max(0.0, min(1.0, scaled)) * 100
+
+
+def _log_scaling(value: float, pivot: float) -> float:
+    if value is None or value <= 0 or pivot <= 0:
+        return 0.0
+
+    numerator = math.log10(value + 1)
+    denominator = math.log10(pivot + 1)
+    if denominator == 0:
+        return 0.0
+
+    return max(0.0, min(1.0, numerator / denominator)) * 100
+
+
+class OnChainAnalyzer:
+    """Score on-chain health using lightweight heuristics."""
+
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        self.config = config or {}
+
+    def analyze(self, asset: Dict[str, Any]) -> ModuleResult:
+        weights_and_scores: List[Tuple[float, float]] = []
+        signals: List[str] = []
+        metrics: Dict[str, Any] = {}
+
+        market_cap = asset.get("market_cap")
+        total_volume = asset.get("total_volume")
+        watchlist_users = asset.get("watchlist_portfolio_users")
+        community = asset.get("community", {}) or {}
+
+        whale_cfg = self.config.get("whale_tracking", {}) or {}
+        if whale_cfg.get("enabled"):
+            weight = float(whale_cfg.get("accumulation_weight", 0.0))
+            if weight > 0:
+                ratio = _safe_ratio(total_volume, market_cap)
+                threshold = float(whale_cfg.get("whale_threshold", 100_000))
+                # Interpret threshold relative to market cap – higher volume implies accumulation.
+                normalized = _scale_ratio(total_volume or 0.0, threshold)
+                weights_and_scores.append((weight, normalized))
+                metrics["whale_volume_ratio"] = ratio
+                if ratio >= 0.15:
+                    signals.append("whale accumulation detected")
+                elif ratio <= 0.02 and total_volume:
+                    signals.append("whale activity muted")
+
+        holder_cfg = self.config.get("holder_analysis", {}) or {}
+        if holder_cfg.get("enabled"):
+            weight = float(holder_cfg.get("concentration_weight", 0.0))
+            if weight > 0:
+                holders_proxy = community.get("reddit_subscribers") or watchlist_users or 0
+                normalized = _log_scaling(float(holders_proxy), pivot=50_000)
+                weights_and_scores.append((weight, normalized))
+                metrics["holder_reach_proxy"] = holders_proxy
+                if holders_proxy and holders_proxy < 2_000:
+                    signals.append("holder base concentrated")
+                elif holders_proxy > 25_000:
+                    signals.append("healthy holder dispersion")
+
+        txn_cfg = self.config.get("transaction_analysis", {}) or {}
+        if txn_cfg.get("enabled"):
+            velocity_weight = float(txn_cfg.get("velocity_weight", 0.0))
+            smart_money_weight = float(txn_cfg.get("smart_money_weight", 0.0))
+
+            price_change_24h = asset.get("price_change_24h")
+            if velocity_weight > 0:
+                # Reward steady positive velocity while penalising strong drawdowns.
+                change = 0.0 if price_change_24h is None else float(price_change_24h)
+                normalized = max(0.0, min(1.0, (change + 20.0) / 40.0)) * 100
+                weights_and_scores.append((velocity_weight, normalized))
+                metrics["price_change_24h"] = change
+                if change >= 15:
+                    signals.append("on-chain velocity accelerating")
+                elif change <= -10:
+                    signals.append("on-chain outflows growing")
+
+            if smart_money_weight > 0:
+                commits = (asset.get("developer") or {}).get("commit_count_4_weeks")
+                smart_score = _log_scaling(float(commits or 0), pivot=200)
+                weights_and_scores.append((smart_money_weight, smart_score))
+                metrics["dev_commit_4w"] = commits or 0
+                if commits and commits > 100:
+                    signals.append("developer activity attracting smart money")
+
+        liquidity_cfg = self.config.get("liquidity", {}) or {}
+        if liquidity_cfg.get("enabled"):
+            pool_weight = float(liquidity_cfg.get("pool_depth_weight", 0.0))
+            lock_weight = float(liquidity_cfg.get("lock_status_weight", 0.0))
+
+            if pool_weight > 0:
+                min_depth = float(liquidity_cfg.get("min_depth_usd", 100_000))
+                depth_score = _scale_ratio(total_volume or 0.0, max(1.0, min_depth))
+                weights_and_scores.append((pool_weight, depth_score))
+                metrics["liquidity_depth_usd"] = total_volume or 0.0
+                if total_volume and total_volume < min_depth:
+                    signals.append("liquidity shallow across pools")
+
+            if lock_weight > 0:
+                # Without explicit lock data we approximate from watchlist growth.
+                lock_proxy = community.get("telegram_users") or watchlist_users or 0
+                lock_score = _log_scaling(float(lock_proxy), pivot=10_000)
+                weights_and_scores.append((lock_weight, lock_score))
+                metrics["liquidity_lock_proxy"] = lock_proxy
+                if lock_proxy and lock_proxy < 1_000:
+                    signals.append("liquidity lock unverified")
+
+        if not weights_and_scores:
+            return ModuleResult(name="onchain", score=0.0, signals=["insufficient on-chain data"], metrics=metrics)
+
+        total_weight = sum(weight for weight, _ in weights_and_scores)
+        if total_weight <= 0:
+            score = 0.0
+        else:
+            score = sum(weight * value for weight, value in weights_and_scores) / total_weight
+
+        return ModuleResult(name="onchain", score=score, signals=sorted(set(signals)), metrics=metrics)
+

--- a/src/analysis/risk.py
+++ b/src/analysis/risk.py
@@ -1,0 +1,129 @@
+"""Risk assessment heuristics covering rug pull and volatility factors."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from src.models import ModuleResult
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _inverse_score(value: float, threshold: float) -> float:
+    if threshold <= 0:
+        return 0.0
+
+    ratio = max(0.0, 1 - (value / threshold))
+    return max(0.0, min(1.0, ratio)) * 100
+
+
+class RiskAnalyzer:
+    """Estimate downside risk using available metadata."""
+
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        self.config = config or {}
+
+    def analyze(self, asset: Dict[str, Any]) -> ModuleResult:
+        weights_and_scores: List[Tuple[float, float]] = []
+        signals: List[str] = []
+        metrics: Dict[str, Any] = {}
+
+        contract_cfg = self.config.get("contract_security", {}) or {}
+        if contract_cfg:
+            weight = float(contract_cfg.get("audit_weight", 0.0))
+            if weight > 0:
+                # Use developer engagement as loose proxy for diligence.
+                audits_proxy = (asset.get("developer") or {}).get("total_issues") or 0
+                score = min(100.0, audits_proxy / 50 * 100)
+                weights_and_scores.append((weight, score))
+                metrics["audit_activity_proxy"] = audits_proxy
+                if audits_proxy == 0 and contract_cfg.get("require_audit"):
+                    signals.append("audit status unknown")
+
+            if contract_cfg.get("honeypot_check"):
+                signals.append("honeypot screening required")
+            if contract_cfg.get("mint_function_check"):
+                signals.append("verify mint controls")
+
+        rug_cfg = self.config.get("rug_pull_indicators", {}) or {}
+        if rug_cfg:
+            liquidity_weight = float(rug_cfg.get("liquidity_lock_weight", 0.0))
+            holder_weight = float(rug_cfg.get("holder_distribution_weight", 0.0))
+            team_weight = float(rug_cfg.get("team_doxxed_weight", 0.0))
+            ownership_weight = float(rug_cfg.get("contract_ownership_weight", 0.0))
+
+            watchlist_users = asset.get("watchlist_portfolio_users") or 0
+            metrics["watchlist_users"] = watchlist_users
+
+            if liquidity_weight > 0:
+                liquidity_score = min(100.0, watchlist_users / 5_000 * 100)
+                weights_and_scores.append((liquidity_weight, liquidity_score))
+                if watchlist_users < 500:
+                    signals.append("liquidity lock risk")
+
+            if holder_weight > 0:
+                community = asset.get("community", {}) or {}
+                holder_proxy = community.get("reddit_subscribers") or 0
+                distribution_score = min(100.0, holder_proxy / 50_000 * 100)
+                weights_and_scores.append((holder_weight, distribution_score))
+                metrics["holder_distribution_proxy"] = holder_proxy
+                if holder_proxy < 1_000:
+                    signals.append("holder distribution concentrated")
+
+            if team_weight > 0:
+                github_stars = (asset.get("developer") or {}).get("github_stars") or 0
+                doxx_score = min(100.0, github_stars / 1_000 * 100)
+                weights_and_scores.append((team_weight, doxx_score))
+                metrics["developer_reputation_proxy"] = github_stars
+
+            if ownership_weight > 0:
+                ownership_score = min(100.0, watchlist_users / 10_000 * 100)
+                weights_and_scores.append((ownership_weight, ownership_score))
+
+        vol_cfg = self.config.get("volatility_metrics", {}) or {}
+        if vol_cfg:
+            weight = float(vol_cfg.get("weight", 0.0))
+            if weight > 0:
+                daily_vol = abs(_safe_float(asset.get("price_change_24h"))) / 100
+                max_daily = _safe_float(vol_cfg.get("max_daily_volatility"), default=0.5)
+                vol_score = _inverse_score(daily_vol, max_daily)
+                weights_and_scores.append((weight, vol_score))
+                metrics["daily_volatility"] = daily_vol
+                if daily_vol > max_daily:
+                    signals.append("daily volatility exceeds tolerance")
+
+                drawdown = abs(_safe_float(asset.get("price_change_30d"))) / 100
+                tolerance = _safe_float(vol_cfg.get("drawdown_tolerance"), default=0.4)
+                drawdown_score = _inverse_score(drawdown, tolerance)
+                # Treat drawdown as an equally weighted component within volatility.
+                weights_and_scores.append((weight, drawdown_score))
+                metrics["drawdown_30d"] = drawdown
+                if drawdown > tolerance:
+                    signals.append("drawdown beyond profile tolerance")
+
+        if not weights_and_scores:
+            return ModuleResult(
+                name="risk_assessment",
+                score=0.0,
+                signals=["risk data unavailable"],
+                metrics=metrics,
+            )
+
+        total_weight = sum(weight for weight, _ in weights_and_scores)
+        if total_weight <= 0:
+            score = 0.0
+        else:
+            score = sum(weight * value for weight, value in weights_and_scores) / total_weight
+
+        return ModuleResult(
+            name="risk_assessment",
+            score=score,
+            signals=sorted(set(signals)),
+            metrics=metrics,
+        )
+

--- a/src/analysis/sentiment.py
+++ b/src/analysis/sentiment.py
@@ -1,0 +1,110 @@
+"""Social and news sentiment heuristics."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from src.models import ModuleResult
+
+
+def _log_score(value: Any, pivot: float) -> float:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+    if numeric <= 0 or pivot <= 0:
+        return 0.0
+
+    import math
+
+    numerator = math.log10(numeric + 1)
+    denominator = math.log10(pivot + 1)
+    if denominator == 0:
+        return 0.0
+
+    return max(0.0, min(1.0, numerator / denominator)) * 100
+
+
+class SentimentAnalyzer:
+    """Evaluate community engagement and news catalysts."""
+
+    def __init__(self, config: Dict[str, Any] | None = None) -> None:
+        self.config = config or {}
+
+    def analyze(self, asset: Dict[str, Any]) -> ModuleResult:
+        weights_and_scores: List[Tuple[float, float]] = []
+        signals: List[str] = []
+        metrics: Dict[str, Any] = {}
+
+        community = asset.get("community", {}) or {}
+        sentiment_votes = asset.get("sentiment_votes_up_percentage")
+
+        twitter_cfg = self.config.get("twitter", {}) or {}
+        if twitter_cfg.get("enabled"):
+            weight = float(twitter_cfg.get("sentiment_weight", 0.0))
+            engagement_weight = float(twitter_cfg.get("engagement_weight", 0.0))
+            followers = community.get("twitter_followers") or 0
+            mentions_target = float(twitter_cfg.get("min_mentions", 50))
+
+            if weight > 0:
+                sentiment_score = _log_score(followers, pivot=200_000)
+                weights_and_scores.append((weight, sentiment_score))
+                metrics["twitter_followers"] = followers
+                if followers < mentions_target * 50:
+                    signals.append("twitter traction light")
+                elif followers > 250_000:
+                    signals.append("twitter buzz elevated")
+
+            if engagement_weight > 0:
+                engagement_score = _log_score(followers, pivot=500_000)
+                weights_and_scores.append((engagement_weight, engagement_score))
+
+        reddit_cfg = self.config.get("reddit", {}) or {}
+        if reddit_cfg.get("enabled"):
+            weight = float(reddit_cfg.get("sentiment_weight", 0.0))
+            subscribers = community.get("reddit_subscribers") or 0
+            active = community.get("reddit_accounts_active_48h") or 0
+            metrics["reddit_subscribers"] = subscribers
+            metrics["reddit_active_48h"] = active
+
+            if weight > 0:
+                reddit_score = _log_score(subscribers + active * 10, pivot=150_000)
+                weights_and_scores.append((weight, reddit_score))
+                if active and active / max(subscribers, 1) > 0.05:
+                    signals.append("reddit discussions trending")
+
+        news_cfg = self.config.get("news", {}) or {}
+        if news_cfg.get("enabled"):
+            weight = float(news_cfg.get("catalyst_weight", 0.0))
+            if weight > 0:
+                up_votes = 0.0 if sentiment_votes is None else float(sentiment_votes)
+                catalyst_score = max(0.0, min(1.0, (up_votes - 40) / 60.0)) * 100
+                weights_and_scores.append((weight, catalyst_score))
+                metrics["sentiment_votes_up_percentage"] = up_votes
+                if up_votes >= 75:
+                    signals.append("news catalysts positive")
+                elif up_votes <= 45:
+                    signals.append("news sentiment cautious")
+
+        if not weights_and_scores:
+            return ModuleResult(
+                name="sentiment",
+                score=0.0,
+                signals=["sentiment data unavailable"],
+                metrics=metrics,
+            )
+
+        total_weight = sum(weight for weight, _ in weights_and_scores)
+        if total_weight <= 0:
+            score = 0.0
+        else:
+            score = sum(weight * value for weight, value in weights_and_scores) / total_weight
+
+        return ModuleResult(
+            name="sentiment",
+            score=score,
+            signals=sorted(set(signals)),
+            metrics=metrics,
+        )
+

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,5 +1,10 @@
 """Dataclasses and value objects shared across the analytics pipeline."""
 
-from .analysis import AssetSignal, IndicatorScore, TechnicalAnalysisResult
+from .analysis import AssetSignal, IndicatorScore, ModuleResult, TechnicalAnalysisResult
 
-__all__ = ["AssetSignal", "IndicatorScore", "TechnicalAnalysisResult"]
+__all__ = [
+    "AssetSignal",
+    "IndicatorScore",
+    "ModuleResult",
+    "TechnicalAnalysisResult",
+]

--- a/src/models/analysis.py
+++ b/src/models/analysis.py
@@ -19,6 +19,26 @@ class IndicatorScore:
 
 
 @dataclass(slots=True)
+class ModuleResult:
+    """Outcome of a non-technical analysis module."""
+
+    name: str
+    score: float
+    signals: List[str] = field(default_factory=list)
+    metrics: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the module into a JSON-compatible dictionary."""
+
+        return {
+            "name": self.name,
+            "score": self.score,
+            "signals": self.signals,
+            "metrics": self.metrics,
+        }
+
+
+@dataclass(slots=True)
 class TechnicalAnalysisResult:
     """Aggregate of technical indicators for a timeframe."""
 
@@ -64,6 +84,7 @@ class AssetSignal:
     signals: List[str]
     analyzer_breakdown: Dict[str, float]
     technical: Dict[str, TechnicalAnalysisResult] = field(default_factory=dict)
+    modules: Dict[str, ModuleResult] = field(default_factory=dict)
     metadata: Dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -81,5 +102,6 @@ class AssetSignal:
                 timeframe: result.to_dict()
                 for timeframe, result in self.technical.items()
             },
+            "modules": {name: module.to_dict() for name, module in self.modules.items()},
             "metadata": self.metadata,
         }

--- a/tests/test_multi_factor_pipeline.py
+++ b/tests/test_multi_factor_pipeline.py
@@ -1,0 +1,202 @@
+"""Tests covering multi-factor analyzers and pipeline integration."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import math
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+from src.analysis import OnChainAnalyzer
+from src.pipeline import QuantScanner
+
+
+def _build_ohlcv_samples(points: int = 240) -> dict:
+    base_time = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    timestamps = [int((base_time + timedelta(hours=i)).timestamp() * 1000) for i in range(points)]
+    prices = [100 + math.sin(i / 12) * 5 + i * 0.05 for i in range(points)]
+
+    return {
+        "timestamps": timestamps,
+        "open": prices,
+        "high": [price * 1.01 for price in prices],
+        "low": [price * 0.99 for price in prices],
+        "close": [price * 1.002 for price in prices],
+        "volume": [150_000 + (i % 24) * 1_000 for i in range(points)],
+    }
+
+
+def test_onchain_analyzer_generates_signals():
+    config = {
+        "whale_tracking": {
+            "enabled": True,
+            "whale_threshold": 50_000,
+            "accumulation_weight": 0.4,
+        },
+        "holder_analysis": {
+            "enabled": True,
+            "concentration_weight": 0.3,
+        },
+        "transaction_analysis": {
+            "enabled": True,
+            "velocity_weight": 0.2,
+            "smart_money_weight": 0.1,
+        },
+        "liquidity": {
+            "enabled": True,
+            "pool_depth_weight": 0.4,
+            "lock_status_weight": 0.1,
+            "min_depth_usd": 120_000,
+        },
+    }
+
+    asset = {
+        "market_cap": 1_500_000,
+        "total_volume": 400_000,
+        "price_change_24h": 18,
+        "watchlist_portfolio_users": 5_000,
+        "developer": {"commit_count_4_weeks": 220},
+        "community": {
+            "reddit_subscribers": 30_000,
+            "telegram_users": 4_500,
+        },
+    }
+
+    analyzer = OnChainAnalyzer(config)
+    result = analyzer.analyze(asset)
+
+    assert result.score > 40
+    assert "whale accumulation detected" in result.signals
+    assert result.metrics["whale_volume_ratio"] > 0
+
+
+class _StaticAdapter:
+    def __init__(self, asset: dict, ohlcv: dict) -> None:
+        self._asset = asset
+        self._ohlcv = ohlcv
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get_asset_data(self, coin_id: str) -> dict:
+        return self._asset
+
+    async def get_ohlcv(self, coin_id: str, days: int = 90, vs_currency: str = "usd") -> dict:
+        return self._ohlcv
+
+
+@pytest.mark.asyncio
+async def test_quant_scanner_produces_multi_factor_scores(tmp_path):
+    config = {
+        "profile": {"name": "unit-test"},
+        "data_sources": {"price_data": {"primary": "test"}},
+        "technical_analysis": {
+            "timeframes": ["1h", "4h", "1d"],
+            "indicators": {
+                "rsi": {"enabled": True, "period": 14, "weight": 0.2},
+                "macd": {"enabled": True, "weight": 0.2},
+                "bollinger_bands": {"enabled": True, "period": 20, "weight": 0.2},
+                "volume_analysis": {"enabled": True, "sma_period": 20, "weight": 0.2},
+                "support_resistance": {"enabled": True, "lookback_periods": 60, "weight": 0.2},
+            },
+        },
+        "onchain_analysis": {
+            "whale_tracking": {"enabled": True, "whale_threshold": 40_000, "accumulation_weight": 0.3},
+            "holder_analysis": {"enabled": True, "concentration_weight": 0.2},
+            "transaction_analysis": {
+                "enabled": True,
+                "velocity_weight": 0.2,
+                "smart_money_weight": 0.1,
+            },
+            "liquidity": {
+                "enabled": True,
+                "pool_depth_weight": 0.2,
+                "lock_status_weight": 0.1,
+                "min_depth_usd": 80_000,
+            },
+        },
+        "market_structure": {
+            "liquidity_metrics": {"min_depth_usd": 60_000, "weight": 0.6},
+            "exchange_distribution": {"cex_weight": 0.2, "dex_weight": 0.2},
+        },
+        "sentiment_analysis": {
+            "twitter": {"enabled": True, "sentiment_weight": 0.3, "engagement_weight": 0.2},
+            "reddit": {"enabled": True, "sentiment_weight": 0.2},
+            "news": {"enabled": True, "catalyst_weight": 0.3},
+        },
+        "risk_assessment": {
+            "contract_security": {"audit_weight": 0.3, "require_audit": False, "honeypot_check": True},
+            "rug_pull_indicators": {
+                "liquidity_lock_weight": 0.2,
+                "team_doxxed_weight": 0.1,
+                "holder_distribution_weight": 0.2,
+                "contract_ownership_weight": 0.1,
+            },
+            "volatility_metrics": {
+                "weight": 0.2,
+                "max_daily_volatility": 0.6,
+                "drawdown_tolerance": 0.5,
+            },
+        },
+        "analyzer_weights": {
+            "technical": 0.3,
+            "onchain": 0.25,
+            "market_structure": 0.2,
+            "sentiment": 0.15,
+            "risk_assessment": 0.1,
+        },
+        "scoring": {
+            "score_ranges": {
+                "high": [70, 100],
+                "medium": [40, 69],
+                "low": [0, 39],
+            }
+        },
+    }
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    asset = {
+        "id": "test-coin",
+        "symbol": "TST",
+        "name": "Test Coin",
+        "market_cap": 2_000_000,
+        "market_cap_rank": 250,
+        "total_volume": 250_000,
+        "price_usd": 1.25,
+        "price_change_24h": 12.0,
+        "price_change_30d": -15.0,
+        "watchlist_portfolio_users": 10_000,
+        "community": {
+            "twitter_followers": 320_000,
+            "reddit_subscribers": 55_000,
+            "reddit_accounts_active_48h": 6_000,
+            "telegram_users": 25_000,
+        },
+        "developer": {
+            "commit_count_4_weeks": 180,
+            "total_issues": 45,
+            "github_stars": 1_500,
+        },
+        "sentiment_votes_up_percentage": 78,
+    }
+
+    adapter = _StaticAdapter(asset, _build_ohlcv_samples())
+    scanner = QuantScanner(str(config_path), adapter=adapter)
+
+    results = await scanner.analyze_assets(["test-coin"], days=30)
+
+    assert results, "Scanner should produce at least one signal"
+    signal = results[0]
+    assert set(signal.modules.keys()) >= {"onchain", "market_structure", "sentiment", "risk_assessment"}
+    assert signal.analyzer_breakdown["technical"] >= 0
+    assert signal.composite_score >= 0
+    assert signal.signals, "Combined signal set should not be empty"
+

--- a/tests/test_technical_analyzer.py
+++ b/tests/test_technical_analyzer.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from datetime import datetime
 
-import numpy as np
-import pandas as pd
+import pytest
+
+np = pytest.importorskip("numpy")
+pd = pytest.importorskip("pandas")
 
 from src.analysis import TechnicalAnalyzer
 


### PR DESCRIPTION
## Summary
- add ModuleResult dataclass support and export new analysis modules
- implement on-chain, market structure, sentiment, and risk analyzers with heuristic scoring
- integrate multi-factor modules into QuantScanner and cover with integration tests while making existing tests dependency-aware

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5dccf16808325b66907c2f3ea420d